### PR TITLE
add CMake to project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,68 @@
+cmake_minimum_required(VERSION 3.22)
+
+set(CMAKE_PROJECT_NAME openosd-x)
+
+# Setup compiler settings
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+
+# Define the build type
+if(NOT CMAKE_BUILD_TYPE)
+    message(STATUS "No build type selected, defaulting to Release")
+    # Default to Release if no build type is specified
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type")
+endif()
+
+
+# Include toolchain file
+include("cmake/gcc-arm-none-eabi.cmake")
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+
+enable_language(C ASM)
+
+# Core project settings
+project(${CMAKE_PROJECT_NAME})
+message("Build type: " ${CMAKE_BUILD_TYPE})
+
+# Create an executable object type
+add_executable(${CMAKE_PROJECT_NAME})
+
+# Add HAL stm32g4xx sources
+add_subdirectory(cmake/stm32g4xx)
+
+# Link directories setup
+target_link_directories(${CMAKE_PROJECT_NAME} PRIVATE
+    # Add defined library search paths
+)
+
+# Add sources to executable
+target_sources(${CMAKE_PROJECT_NAME} PRIVATE
+    # Add sources here
+    ./Src/Core/Src/main.c
+    ./Src/Core/Src/stm32g4xx_it.c
+    ./Src/Core/Src/stm32g4xx_hal_msp.c
+    ./Src/Core/Src/system_stm32g4xx.c
+    ./Src/Core/Src/sysmem.c
+    ./Src/Core/Src/syscalls.c
+    ./Src/Core/Startup/startup_stm32g431kbtx.s
+)
+
+# Add include paths
+target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
+    # Add defined include paths
+    ./Src/Core/Inc
+)
+
+# Add project symbols (macros)
+target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE
+    # Add defined symbols
+)
+
+# Add linked libraries
+target_link_libraries(${CMAKE_PROJECT_NAME}
+    stm32g4xx
+    # Add defined libraries
+)

--- a/cmake/gcc-arm-none-eabi.cmake
+++ b/cmake/gcc-arm-none-eabi.cmake
@@ -1,0 +1,48 @@
+set(CMAKE_SYSTEM_NAME               Generic)
+set(CMAKE_SYSTEM_PROCESSOR          arm)
+
+set(CMAKE_C_COMPILER_FORCED TRUE)
+set(CMAKE_CXX_COMPILER_FORCED TRUE)
+set(CMAKE_C_COMPILER_ID GNU)
+set(CMAKE_CXX_COMPILER_ID GNU)
+
+# Some default GCC settings
+# arm-none-eabi- must be part of path environment
+set(TOOLCHAIN_PREFIX                arm-none-eabi-)
+
+set(CMAKE_C_COMPILER                ${TOOLCHAIN_PREFIX}gcc)
+set(CMAKE_ASM_COMPILER              ${CMAKE_C_COMPILER})
+set(CMAKE_CXX_COMPILER              ${TOOLCHAIN_PREFIX}g++)
+set(CMAKE_LINKER                    ${TOOLCHAIN_PREFIX}g++)
+set(CMAKE_OBJCOPY                   ${TOOLCHAIN_PREFIX}objcopy)
+set(CMAKE_SIZE                      ${TOOLCHAIN_PREFIX}size)
+
+set(CMAKE_EXECUTABLE_SUFFIX_ASM     ".elf")
+set(CMAKE_EXECUTABLE_SUFFIX_C       ".elf")
+set(CMAKE_EXECUTABLE_SUFFIX_CXX     ".elf")
+
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+# MCU specific flags
+set(TARGET_FLAGS "-mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard ")
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${TARGET_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wpedantic -fdata-sections -ffunction-sections")
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -g3")
+endif()
+if(CMAKE_BUILD_TYPE MATCHES Release)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os -g0")
+endif()
+
+set(CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS} -x assembler-with-cpp -MMD -MP")
+set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -fno-rtti -fno-exceptions -fno-threadsafe-statics")
+
+set(CMAKE_C_LINK_FLAGS "${TARGET_FLAGS}")
+set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -T \"${CMAKE_SOURCE_DIR}/Src/stm32g431kbtx_flash.ld\"")
+set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} --specs=nano.specs")
+set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -Wl,-Map=${CMAKE_PROJECT_NAME}.map -Wl,--gc-sections")
+set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -Wl,--start-group -lc -lm -Wl,--end-group")
+set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -Wl,--print-memory-usage")
+
+set(CMAKE_CXX_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -Wl,--start-group -lstdc++ -lsupc++ -Wl,--end-group")

--- a/cmake/stm32g4xx/CMakeLists.txt
+++ b/cmake/stm32g4xx/CMakeLists.txt
@@ -1,0 +1,63 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(stm32g4xx)
+add_library(stm32g4xx INTERFACE)
+
+# Enable CMake support for ASM and C languages
+enable_language(C ASM)
+
+target_compile_definitions(stm32g4xx INTERFACE 
+	USE_HAL_DRIVER 
+	STM32G431xx
+    $<$<CONFIG:Debug>:DEBUG>
+)
+
+target_include_directories(stm32g4xx INTERFACE
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Inc
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Inc/Legacy
+    ../../Src/Drivers/CMSIS/Device/ST/STM32G4xx/Include
+    ../../Src/Drivers/CMSIS/Include
+)
+
+target_sources(stm32g4xx INTERFACE
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_adc.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_adc_ex.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_ll_adc.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_rcc.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_rcc_ex.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_flash.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_flash_ex.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_flash_ramfunc.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_gpio.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_exti.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_dma.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_dma_ex.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_pwr.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_pwr_ex.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_cortex.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_comp.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_dac.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_dac_ex.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_opamp.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_opamp_ex.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_spi.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_spi_ex.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_tim.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_tim_ex.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_uart.c
+    ../../Src/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_uart_ex.c
+)
+
+target_link_directories(stm32g4xx INTERFACE
+)
+
+target_link_libraries(stm32g4xx INTERFACE
+)
+
+# Validate that stm32g4xx code is compatible with C standard
+if(CMAKE_C_STANDARD LESS 11)
+    message(ERROR "Generated code requires C11 or higher")
+endif()
+
+


### PR DESCRIPTION
CMake added for easy building without an IDE


While CMake cannot check version and install `gcc-arm-none-eabi` compiller, this can be added later

How to use for Linux, MacOS:
```bash
mkdir build && cd build
cmake ..
build 
```